### PR TITLE
Support pow() as an argument for derivative()

### DIFF
--- a/src/function/algebra/derivative.js
+++ b/src/function/algebra/derivative.js
@@ -300,6 +300,10 @@ function factory (type, config, load, typed) {
             ]), constNodes)
           }
           break
+        case 'pow':
+          constNodes[arg1] = constNodes[node.args[1]]
+          // Pass to pow operator node parser
+          return _derivative(new OperatorNode('^', 'pow', [arg0, node.args[1]]), constNodes)
         case 'exp':
           // d/dx(e^x) = e^x
           funcDerivative = new FunctionNode('exp', [arg0.clone()])
@@ -746,7 +750,7 @@ function factory (type, config, load, typed) {
    */
   function funcArgsCheck (node) {
     // TODO add min, max etc
-    if ((node.name === 'log' || node.name === 'nthRoot') && node.args.length === 2) {
+    if ((node.name === 'log' || node.name === 'nthRoot' || node.name === 'pow') && node.args.length === 2) {
       return
     }
 


### PR DESCRIPTION
Add support for the pow() function as an argument for math.derivative().

Fixes #1259.